### PR TITLE
skip empty chapters

### DIFF
--- a/audiblez.py
+++ b/audiblez.py
@@ -42,6 +42,8 @@ def main(kokoro, file_path, lang, voice):
     i = 1
     chapter_mp3_files = []
     for text in texts:
+        if len(text) == 0:
+            continue
         chapter_filename = filename.replace('.epub', f'_chapter_{i}.wav')
         chapter_mp3_files.append(chapter_filename)
         if Path(chapter_filename).exists():


### PR DESCRIPTION
Hi,
while using the package I came across a problem that the title page was recognized as a chapter and it led to the following error since it did not contain any text. This basic fix solved the issue for me.

```)Traceback (most recent call last):
  File ".../audiblez", line 8, in <module>
    sys.exit(cli_main())
             ^^^^^^^^^^
  File ".../audiblez.py", line 163, in cli_main
    main(kokoro, args.epub_file_path, args.lang, args.voice)
  File ".../audiblez.py", line 55, in main
    samples, sample_rate = kokoro.create(text, voice=voice, speed=1.0, lang=lang)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../kokoro_onnx/__init__.py", line 152, in create
    audio = np.concatenate(audio)
            ^^^^^^^^^^^^^^^^^^^^^
ValueError: need at least one array to concatenate```)