### PR TITLE
Adds generation of chapter markings in the audiobook

### DIFF
--- a/.github/workflows/pip-install.yaml
+++ b/.github/workflows/pip-install.yaml
@@ -19,14 +19,14 @@ jobs:
         run: python -m audiblez --help
       - name: check it runs as script
         run: audiblez --help
-#      - name: install ffmpeg
-#        run: sudo apt-get install ffmpeg
-#      - name: download test epub
-#        run: wget https://github.com/daisy/epub-accessibility-tests/releases/download/fundamental-2.0/Fundamental-Accessibility-Tests-Basic-Functionality-v2.0.0.epub
-#      - name: create audiobook
-#        run: audiblez Fundamental-Accessibility-Tests-Basic-Functionality-v2.0.0.epub
-#      - name: check m4b output file
-#        run: ls -lah Fundamental-Accessibility-Tests-Basic-Functionality-v2.0.0.m4b
+      - name: install ffmpeg
+        run: sudo apt-get install ffmpeg
+      - name: download test epub
+        run: wget https://github.com/daisy/epub-accessibility-tests/releases/download/fundamental-2.0/Fundamental-Accessibility-Tests-Basic-Functionality-v2.0.0.epub
+      - name: create audiobook
+        run: audiblez Fundamental-Accessibility-Tests-Basic-Functionality-v2.0.0.epub
+      - name: check m4b output file
+        run: ls -lah Fundamental-Accessibility-Tests-Basic-Functionality-v2.0.0.m4b
   install-and-run-on-python-3-12:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This patch tracks the length of the generated audio (or uses ffprobe to recover it from the files if not available e.g. when files are already present) and generates a chapters file that is fed to ffmpeg to add chapter markings.