### PR TITLE
Support for onnxruntime-gpu and documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ epub
 *.json
 *.onnx
 dist
+.venv

--- a/README.md
+++ b/README.md
@@ -33,13 +33,46 @@ audiblez book.epub -l en-gb -v af_sky
 
 It will first create a bunch of `book_chapter_1.wav`, `book_chapter_2.wav`, etc. files in the same directory,
 and at the end it will produce a `book.m4b` file with the whole book you can listen with VLC or any
- audiobook player.
+audiobook player.
 It will only produce the `.m4b` file if you have `ffmpeg` installed on your machine.
+
+### Using the `--providers` option for ONNX
+
+If you want to use a GPU for faster performance, install the GPU-enabled ONNX Runtime and specify a runtime provider with the `--providers` flag. By default, the CPU-enabled ONNX Runtime is installed. The GPU runtime must be installed manually.
+
+```bash
+pip install onnxruntime-gpu
+```
+
+To specify ONNX providers, such as using an NVIDIA GPU, use the `--providers` tag. For example:
+
+```bash
+audiblez book.epub -l en-gb -v af_sky --providers CUDAExecutionProvider
+```
+
+To see the list of available providers on your system, run the following:
+
+```bash
+audiblez --help
+```
+
+or
+
+```bash
+python -c "import onnxruntime as ort; print(ort.get_available_providers())"
+```
+
+This will display the ONNX providers that can be used, such as `CUDAExecutionProvider` for NVIDIA GPUs or `CPUExecutionProvider` for CPU-only execution.
+
+You can specify a provider hierarchy by providing multiple hierarchies separated by spaces.
+
+```bash
+audiblez book.epub -l en-gb -v af_sky --providers CUDAExecutionProvider CPUExecutionProvider
+```
 
 ## Supported Languages
 Use `-l` option to specify the language, available language codes are:
 🇺🇸 `en-us`, 🇬🇧 `en-gb`, 🇫🇷 `fr-fr`, 🇯🇵 `ja`, 🇰🇷 `kr` and 🇨🇳 `cmn`.
-
 
 ## Speed
 By default the audio is generated using a normal speed, but you can make it up to twice slower or faster by specifying a speed argument between 0.5 to 2.0:


### PR DESCRIPTION
### Pull Request: Add ONNXRuntime Provider Support and Documentation Updates

#### Summary
This PR introduces support for specifying ONNXRuntime providers via the `--providers` CLI option, enabling users to optimize audiobook generation performance. It also updates documentation to include instructions for GPU acceleration with `onnxruntime-gpu`.

---

#### Key Changes
1. **ONNXRuntime Provider Support:**
   - Added `--providers` argument to specify execution providers (e.g., `CUDAExecutionProvider`).
   - Validates user-provided providers against available options.

2. **Dynamic Help:**
   - `--providers` help text now includes the list of available ONNXRuntime providers on the system.

3. **Documentation Updates:**
   - Added instructions for installing `onnxruntime-gpu`.
   - Included examples for using `--providers` and checking available providers.

---

#### Testing
- Verify default behavior remains unchanged without `--providers`.
- Test with valid providers (e.g., `CUDAExecutionProvider`) and confirm correct application.
- Validate error handling for invalid providers.
- Check `--help` output for accurate provider information.

---

#### Compatibility
These changes are fully backward compatible. The `--providers` argument is optional, and the default provider (`CPUExecutionProvider`) is used when none is specified.

---

#### Example
```bash
audiblez book.epub -l en-gb -v af_sky --providers CUDAExecutionProvider
```
