### PR TITLE
Fix: wxPython dependency issue on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,15 @@ dependencies = [
     "spacy (>=3.8.3,<4.0.0)",
     "kokoro (>=0.7.9,<0.8.0)",
     "misaki[zh] (>=0.7.10,<0.8.0)",
-    "tabulate (>=0.9.0,<0.10.0)",
+    "tabulate (>=0.9.0,<0.10.0)"
 ]
-exclude = [
-    "imgs",
-    "test",
-    "*.wav",
-    "*.m4b",
-    "cover",
-    "chapters.txt"
+
+# Optional GUI dependencies for the UI entrypoint.
+[project.optional-dependencies]
+ui = [
+    # Wheels exist for macOS/Py3.12; keep platform marker so Linux headless users aren't forced to build it.
+    "wxPython>=4.2.2; sys_platform == 'darwin'",
+    "pillow>=10.0.0"
 ]
 
 [build-system]
@@ -39,6 +39,17 @@ Issues = "https://github.com/santinic/audiblez/issues"
 [project.scripts]
 audiblez = "audiblez.cli:cli_main"
 audiblez-ui = "audiblez.ui:main"
+
+[tool.poetry]
+# Preserve the author's original file excludes (moved here from [project]).
+exclude = [
+    "imgs",
+    "test",
+    "*.wav",
+    "*.m4b",
+    "cover",
+    "chapters.txt"
+]
 
 [tool.poetry.group.dev.dependencies]
 deptry = "^0.23.0"


### PR DESCRIPTION
PR: Fix excludes & add optional UI dependencies

What this does
	•	Fixes build error
The exclude = [...] block was under [project], which isn’t valid PEP 621.
This caused Poetry/uv to parse *.wav as a dependency and fail.
→ Moved exclude to [tool.poetry]
	•	Adds optional ui extra
For audiblez-ui, GUI dependencies are now declared under [project.optional-dependencies].ui:
	•	wxPython>=4.2.2; sys_platform == 'darwin'
	•	pillow>=10.0.0
This keeps headless users lean, while allowing GUI installs via:

```python
uv sync --extra ui
uv run audiblez-ui
```

