### PR TITLE
fix ffmpeg v8

### DIFF
--- a/audiblez/core.py
+++ b/audiblez/core.py
@@ -297,7 +297,7 @@ def concat_wavs_with_ffmpeg(chapter_files, output_folder, filename):
     with open(wav_list_txt, 'w') as f:
         for wav_file in chapter_files:
             f.write(f"file '{wav_file}'\n")
-    concat_file_path = Path(output_folder) / filename.replace('.epub', '.tmp.mp4')
+    concat_file_path = Path(output_folder) / filename.replace('.epub', '.tmp.wav')
     subprocess.run(['ffmpeg', '-y', '-f', 'concat', '-safe', '0', '-i', wav_list_txt, '-c', 'copy', concat_file_path])
     Path(wav_list_txt).unlink()
     return concat_file_path


### PR DESCRIPTION
FFmpeg v8 added more restrictions when muxing. I found that it fails (creates a file with no audio) when trying to mux the wav files into a `.mp4` on FFmpeg v8, but not FFmpeg v6. It is a super simple fix: just change the file extension for the temporary file to be `.wav`. Doing this also seems to trigger a re-encode (despite to the command to copy?) and greatly decreases file sizes.