### PR TITLE
Add step to close conflicting applications before install

### DIFF
--- a/.github/workflows/pip-install.yaml
+++ b/.github/workflows/pip-install.yaml
@@ -54,6 +54,10 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.11"
+      - name: Close potentially conflicting applications
+        run: |
+          Get-Process | Where-Object {$_.ProcessName -match "explorer|taskhostw"} | Stop-Process -Force -ErrorAction SilentlyContinue
+          Start-Sleep -Seconds 2
       - name: Install winget
         uses: Cyberboss/install-winget@v1
       - name: Install wingetcreate


### PR DESCRIPTION
This action fails with the error code 

Add-AppxPackage : Deployment failed with HRESULT: 0x80073D02, The package could not be installed because resources it modifies are currently in use.

This change stops any processes that would be being used to allow the installation to go thru correctly.