### PR TITLE
fix(core): handle Kindle-EPUB chapter naming and dedupe nested <li><p…

### DIFF
--- a/audiblez/core.py
+++ b/audiblez/core.py
@@ -251,7 +251,13 @@ def gen_text(text, voice='af_heart', output_file='text.wav', speed=1, play=False
 
 
 def find_document_chapters_and_extract_texts(book):
-    """Returns every chapter that is an ITEM_DOCUMENT and enriches each chapter with extracted_text."""
+    """Returns every chapter that is an ITEM_DOCUMENT and enriches each chapter with extracted_text.
+
+    Skips any matched tag whose ancestor is also a matched tag, otherwise nested
+    structures like <li><p>text</p></li> get extracted twice (once via <li>.text
+    walking into the <p>, once via <p>.text directly), causing repeated content
+    in the audio output.
+    """
     document_chapters = []
     for chapter in book.get_items():
         if chapter.get_type() != ebooklib.ITEM_DOCUMENT:
@@ -260,7 +266,14 @@ def find_document_chapters_and_extract_texts(book):
         soup = BeautifulSoup(xml, features='lxml')
         chapter.extracted_text = ''
         html_content_tags = ['title', 'p', 'h1', 'h2', 'h3', 'h4', 'li']
-        for text in [c.text.strip() for c in soup.find_all(html_content_tags) if c.text]:
+        all_matched = soup.find_all(html_content_tags)
+        matched_ids = {id(t) for t in all_matched}
+        for tag in all_matched:
+            if any(id(p) in matched_ids for p in tag.parents):
+                continue  # ancestor will emit this text already
+            text = tag.text.strip() if tag.text else ''
+            if not text:
+                continue
             if not text.endswith('.'):
                 text += '.'
             chapter.extracted_text += text + '\n'
@@ -289,10 +302,19 @@ def chapter_beginning_one_liner(c, chars=20):
 
 
 def find_good_chapters(document_chapters):
-    chapters = [c for c in document_chapters if c.get_type() == ebooklib.ITEM_DOCUMENT and is_chapter(c)]
-    if len(chapters) == 0:
-        print('Not easy to recognize the chapters, defaulting to all non-empty documents.')
-        chapters = [c for c in document_chapters if c.get_type() == ebooklib.ITEM_DOCUMENT and len(c.extracted_text) > 10]
+    docs_with_text = [c for c in document_chapters
+                      if c.get_type() == ebooklib.ITEM_DOCUMENT and len(c.extracted_text) > 10]
+    chapters = [c for c in docs_with_text if is_chapter(c)]
+    # The is_chapter() heuristic searches for substrings like "ch\d" anywhere in
+    # the filename. In Kindle-converted EPUBs many docs are named "c0.xhtml",
+    # "cH7.xhtml" etc., where the lowercase "ch7" can accidentally satisfy the
+    # regex even though the file is just one of many flat content docs. Require
+    # at least 3 matches before trusting the pattern, otherwise treat all
+    # non-empty docs as chapters.
+    if len(chapters) < 3:
+        print(f'Only {len(chapters)} doc(s) matched the chapter-name pattern '
+              f'(of {len(docs_with_text)} non-empty docs); defaulting to all of them.')
+        return docs_with_text
     return chapters
 
 

--- a/test_fixes.py
+++ b/test_fixes.py
@@ -1,0 +1,25 @@
+"""Verify the two fixes against EPUBs known to trigger each bug."""
+import os
+from ebooklib import epub
+from audiblez import core
+
+
+print('=== Fix B: dedupe nested matches ===')
+mind_play = 'c:/Users/magee/repos/k2go/converted/Mind Play__105.epub'
+book = epub.read_epub(mind_play)
+docs = core.find_document_chapters_and_extract_texts(book)
+total = sum(len(c.extracted_text) for c in docs)
+# Original (broken): 454,383 chars  | Fixed: 393,349 chars (61,034 saved, 13.4%)
+print(f'Mind Play extracted text: {total:,} chars')
+print(f'Expected ~393,349 (would be 454,383 with the bug); '
+      f'{"FIX WORKING" if total < 400000 else "FIX NOT APPLIED"}')
+
+print()
+print('=== Fix A: chapter detection threshold ===')
+communicate = 'c:/Users/magee/repos/k2go/converted/Communicate About Sex (without making it awkward)_ Healthy and Shame-Free Ways to Talk with Your Partner about Sexual De__102.epub'
+book2 = epub.read_epub(communicate)
+docs2 = core.find_document_chapters_and_extract_texts(book2)
+chapters = core.find_good_chapters(docs2)
+print(f'Communicate About Sex selected chapters: {len(chapters)}')
+print(f'Expected many (~30+); '
+      f'{"FIX WORKING" if len(chapters) >= 10 else "FIX NOT APPLIED — only 1 chapter selected"}')


### PR DESCRIPTION
…> extraction

- find_good_chapters now requires >=3 matches before trusting the is_chapter heuristic, otherwise treats all non-empty docs as chapters. converted EPUBs have filenames like c0.xhtml, cH7.xhtml that randomly satisfy the regex on a single file, causing 33 of 34 chapters to be silently skipped.

- find_document_chapters_and_extract_texts now skips any matched tag whose ancestor is also matched. Nested <li><p>text</p></li> structures were being extracted twice, causing repeated paragraphs in the audio.

  fixes: https://github.com/santinic/audiblez/issues/124 https://github.com/santinic/audiblez/issues/100 and https://github.com/santinic/audiblez/issues/124