### PR TITLE
Fix m4b assembly failing with FileNotFoundError when libfdk_aac unavailable

### DIFF
--- a/audiblez/core.py
+++ b/audiblez/core.py
@@ -327,12 +327,21 @@ def concat_wavs_with_ffmpeg(chapter_files, output_folder, filename):
         for wav_file in chapter_files:
             f.write(f"file '{wav_file}'\n")
     concat_file_path = Path(output_folder) / filename.replace('.epub', '.tmp.mp4')
-    subprocess.run([
+    # Default to ffmpeg's built-in 'aac' encoder, which ships with every build.
+    # libfdk_aac is non-free and absent from Homebrew's default ffmpeg, where
+    # it silently fails and leaves no output file.
+    encoder = os.environ.get('AUDIBLEZ_AAC_ENCODER', 'aac')
+    proc = subprocess.run([
         'ffmpeg', '-y', '-f', 'concat', '-safe', '0', '-i', wav_list_txt,
-        # '-c', 'copy',
-        '-c:a',  'libfdk_aac',
+        '-c:a',  encoder,
         '-b:a',  '192k',
         concat_file_path])
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg concat failed (exit {proc.returncode}) using encoder "
+            f"'{encoder}'. If this encoder is unavailable in your ffmpeg "
+            f"build, unset AUDIBLEZ_AAC_ENCODER to use the default 'aac'."
+        )
     Path(wav_list_txt).unlink()
     return concat_file_path
 
@@ -374,10 +383,14 @@ def create_m4b(chapter_files, filename, cover_image, output_folder):
         f'{final_filename}'  # Output file
     ])
 
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg m4b assembly failed (exit {proc.returncode}). "
+            f"Intermediate file left at {concat_file_path} for inspection."
+        )
     Path(concat_file_path).unlink()
-    if proc.returncode == 0:
-        print(f'{final_filename} created. Enjoy your audiobook.')
-        print('Feel free to delete the intermediary .wav chapter files, the .m4b is all you need.')
+    print(f'{final_filename} created. Enjoy your audiobook.')
+    print('Feel free to delete the intermediary .wav chapter files, the .m4b is all you need.')
 
 
 def probe_duration(file_name):


### PR DESCRIPTION
## Problem

`concat_wavs_with_ffmpeg()` invokes ffmpeg with `-c:a libfdk_aac`, a non-free encoder that is **not in Homebrew's default ffmpeg build** and absent from many distro packages. When unavailable:

1. ffmpeg exits non-zero.
2. The `.tmp.mp4` is never written.
3. The subprocess return code is **not checked** — `concat_wavs_with_ffmpeg()` returns a path to a file that doesn't exist.
4. `create_m4b()` then proceeds and finally calls `Path(concat_file_path).unlink()`, which raises `FileNotFoundError`.

User-visible result: a confusing `FileNotFoundError: …tmp.mp4` at the very end of an otherwise-successful TTS run, with no hint that the real failure was an unsupported encoder. The WAV files are all generated; only the m4b assembly fails.

## Reproduction

On macOS with default Homebrew ffmpeg:

```bash
ffmpeg -hide_banner -encoders 2>/dev/null | grep -i fdk
# (empty — libfdk_aac is not available)

audiblez some.epub -o /tmp/test
# ... runs all chapters successfully ...
# FileNotFoundError: [Errno 2] No such file or directory: '/tmp/test/some.tmp.mp4'
```

## Fix

Two small, self-contained changes in `audiblez/core.py`:

**1. Switch the default encoder to ffmpeg's built-in `aac`.** Ships with every ffmpeg build; quality at 192k is fine for narration. Users who do have `libfdk_aac` can opt back in via an `AUDIBLEZ_AAC_ENCODER=libfdk_aac` env var.

**2. Check the subprocess return code at both ffmpeg call sites.** If ffmpeg fails, raise a clear `RuntimeError` naming the encoder and the exit code, rather than letting it surface as a downstream `FileNotFoundError`.

## Backwards compatibility

- Existing users who happened to have `libfdk_aac` available (e.g. a custom Homebrew tap or self-built ffmpeg) can keep using it: `AUDIBLEZ_AAC_ENCODER=libfdk_aac audiblez book.epub`. Default behavior changes from "use libfdk_aac, crash if absent" to "use aac, work everywhere."
- No new dependencies, no API changes.

## Testing

- Reproduced the original `FileNotFoundError` on Homebrew's default ffmpeg.
- Verified with the fix that `audiblez book.epub -o /tmp/test` produces a playable `book.m4b` (opens in QuickTime / Music, ffprobe shows correct chapter markers).
- Verified that intentionally setting `AUDIBLEZ_AAC_ENCODER=nonexistent` now raises the new `RuntimeError` with a clear message instead of the old confusing `FileNotFoundError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
