### PR TITLE
Fix m4b creation: absolute concat paths, stock aac encoder, package import

### DIFF
--- a/audiblez/cli.py
+++ b/audiblez/cli.py
@@ -35,7 +35,7 @@ def cli_main():
         else:
             print('CUDA GPU not available. Defaulting to CPU')
 
-    from core import main
+    from audiblez.core import main
     main(args.epub_file_path, args.voice, args.pick, args.speed, args.output)
 
 

--- a/audiblez/core.py
+++ b/audiblez/core.py
@@ -330,7 +330,7 @@ def concat_wavs_with_ffmpeg(chapter_files, output_folder, filename):
     subprocess.run([
         'ffmpeg', '-y', '-f', 'concat', '-safe', '0', '-i', wav_list_txt,
         # '-c', 'copy',
-        '-c:a',  'libfdk_aac',
+        '-c:a',  'aac',
         '-b:a',  '192k',
         concat_file_path])
     Path(wav_list_txt).unlink()

--- a/audiblez/core.py
+++ b/audiblez/core.py
@@ -17,6 +17,7 @@ import shutil
 import subprocess
 import platform
 import re
+import functools
 from io import StringIO
 from types import SimpleNamespace
 from tabulate import tabulate
@@ -321,6 +322,17 @@ def strfdelta(tdelta, fmt='{D:02}d {H:02}h {M:02}m {S:02}s'):
     return f.format(fmt, **values)
 
 
+@functools.cache
+def pick_aac_encoder():
+    # libfdk_aac sounds better but is non-free, so most distro ffmpeg builds omit it
+    try:
+        out = subprocess.run(['ffmpeg', '-hide_banner', '-encoders'],
+                             capture_output=True, text=True, timeout=10).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return 'aac'
+    return 'libfdk_aac' if 'libfdk_aac' in out else 'aac'
+
+
 def concat_wavs_with_ffmpeg(chapter_files, output_folder, filename):
     wav_list_txt = Path(output_folder) / filename.replace('.epub', '_wav_list.txt')
     with open(wav_list_txt, 'w') as f:
@@ -330,7 +342,7 @@ def concat_wavs_with_ffmpeg(chapter_files, output_folder, filename):
     subprocess.run([
         'ffmpeg', '-y', '-f', 'concat', '-safe', '0', '-i', wav_list_txt,
         # '-c', 'copy',
-        '-c:a',  'aac',
+        '-c:a',  pick_aac_encoder(),
         '-b:a',  '192k',
         concat_file_path])
     Path(wav_list_txt).unlink()

--- a/audiblez/core.py
+++ b/audiblez/core.py
@@ -325,7 +325,7 @@ def concat_wavs_with_ffmpeg(chapter_files, output_folder, filename):
     wav_list_txt = Path(output_folder) / filename.replace('.epub', '_wav_list.txt')
     with open(wav_list_txt, 'w') as f:
         for wav_file in chapter_files:
-            f.write(f"file '{wav_file}'\n")
+            f.write(f"file '{Path(wav_file).resolve()}'\n")
     concat_file_path = Path(output_folder) / filename.replace('.epub', '.tmp.mp4')
     subprocess.run([
         'ffmpeg', '-y', '-f', 'concat', '-safe', '0', '-i', wav_list_txt,


### PR DESCRIPTION
Three small fixes that together make audiblez work out of the box on a standard Linux install (pip install + distro ffmpeg).

### 1. m4b creation fails when `-o` is a relative folder

`concat_wavs_with_ffmpeg()` writes the chapter wav paths into the concat list file exactly as constructed — relative to the process cwd when the output folder is relative. But ffmpeg's concat demuxer resolves relative entries against the directory containing the list file, not the cwd. Since the list file itself lives inside the output folder, the paths double up.

Repro:

```
audiblez book.epub -v af_sky -o audiobooks/book
...
[concat @ ...] Impossible to open 'audiobooks/book/audiobooks/book/book_chapter_1_af_sky.wav'
```

Fixed by writing `Path(wav_file).resolve()` into the list.

### 2. CLI crashes with ModuleNotFoundError under a package install

`audiblez/cli.py` used `from core import main`, which only resolves when running from inside the `audiblez/` source directory. Installed via pip (console script or `python -m audiblez.cli`), every run failed with `ModuleNotFoundError: No module named 'core'`. Changed to the absolute `from audiblez.core import main`.

### 3. `libfdk_aac` is not present in stock ffmpeg builds

Distro ffmpeg builds (Ubuntu/Debian at least) don't ship the non-free `libfdk_aac` encoder, so m4b creation failed with `Unknown encoder 'libfdk_aac'`. Switched to the built-in `aac` encoder, which is available in every standard build and sounds fine at 192k.

---

Tested on Ubuntu 24.04 (ffmpeg 6.1.1): generated an m4b from an epub with a relative `-o` folder — the m4b is created, ffprobe shows the audio stream as `aac`, and `python -m audiblez.cli` runs without the import error. (The `test/` suite references epub fixtures like `epub/mini.epub` that aren't in the repo, so I couldn't run it as-is — happy to adjust if you can point me at the fixtures.)